### PR TITLE
Bump com.fasterxml.jackson.core:jackson-databind to 2.10.0 (Hacktoberfest contribution)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.3</version>
+            <version>2.10.0</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>


### PR DESCRIPTION
To comply with issue #1. Bumped com.fasterxml.jackson.core:jackson-databind to 2.10.0